### PR TITLE
Problem: unused command line argument warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ cxx_flags += $(CXX_FLAGS) -ffreestanding -nostdlib -nostdinc -fno-exceptions -fn
 	     -fpic -fstack-protector-all -mno-red-zone --std=c++20 \
 	     -I libpara -Wall -Werror $(depflags)
 
-pcm_cxx_flags +=  -mcmodel=kernel
+pcm_cxx_flags +=  -mcmodel=kernel -Wno-unused-command-line-argument
 
 ifeq ($(RELEASE),false)
   cxx_flags += -g -fstack-size-section


### PR DESCRIPTION
On some platforms (like NixOS), I get unused command line argument
warning with Clang:

```
clang-13: warning: argument unused during compilation: '-idirafter /nix/store/4iwzsqrxpwhb7hzizpr4m3gi1pclq6ij-glibc-2.32-54-dev/include' [-Wunused-command-line-argument]
```

Solution: disable this warning